### PR TITLE
US888096: Support java 8

### DIFF
--- a/docker-versions-maven-plugin/src/main/java/com/github/cafapi/docker_versions/docker/client/DockerRegistryRestClient.java
+++ b/docker-versions-maven-plugin/src/main/java/com/github/cafapi/docker_versions/docker/client/DockerRegistryRestClient.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -140,7 +141,11 @@ public final class DockerRegistryRestClient
 
         try {
             // Make the initial request to get the first page of tags
-            Map<String, String> nextPageParams = appendPageOfTagsToSpecifiedList(url, Map.of("n", "1000"), authToken, allTags);
+            Map<String, String> nextPageParams = appendPageOfTagsToSpecifiedList(
+                url,
+                Collections.singletonMap("n", "1000"),
+                authToken,
+                allTags);
 
             // Fetch subsequent pages until there are no more tags
             while (nextPageParams != null) {

--- a/docker-versions-maven-plugin/src/main/java/com/github/cafapi/docker_versions/plugins/DockerVersionsHelper.java
+++ b/docker-versions-maven-plugin/src/main/java/com/github/cafapi/docker_versions/plugins/DockerVersionsHelper.java
@@ -103,7 +103,7 @@ public final class DockerVersionsHelper
                         repository = PomHelper.evaluate(pom.getElementText().trim(), implicitProperties);
 
                         final Optional<Xpp3Dom> repo = findRepository(repository, imagesConfig);
-                        if (repo.isEmpty()) {
+                        if (!repo.isPresent()) {
                             needsUpdate = false;
                         } else {
                             LOGGER.debug("Updating repo : {}", repository);

--- a/docker-versions-maven-plugin/src/main/java/com/github/cafapi/docker_versions/plugins/PopulateProjectRegistryMojo.java
+++ b/docker-versions-maven-plugin/src/main/java/com/github/cafapi/docker_versions/plugins/PopulateProjectRegistryMojo.java
@@ -150,7 +150,7 @@ public final class PopulateProjectRegistryMojo extends DockerVersionsMojo
 
             LOGGER.debug("Pulled image '{}', verify that it is now present...", imageName);
             final Optional<InspectImageResponse> image = dockerClient.findImage(imageName);
-            if (image.isEmpty()) {
+            if (!image.isPresent()) {
                 throw new ImagePullException("Image not found after pulling it: " + imageName);
             }
 

--- a/docker-versions-maven-plugin/src/main/java/com/github/cafapi/docker_versions/plugins/extension/DockerVersionsLifecycleParticipant.java
+++ b/docker-versions-maven-plugin/src/main/java/com/github/cafapi/docker_versions/plugins/extension/DockerVersionsLifecycleParticipant.java
@@ -15,11 +15,11 @@
  */
 package com.github.cafapi.docker_versions.plugins.extension;
 
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
@@ -45,8 +45,8 @@ public final class DockerVersionsLifecycleParticipant extends AbstractMavenLifec
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(DockerVersionsLifecycleParticipant.class);
 
-    private static final List<String> AVOID_AUTO_POPULATE_PHASES = List.of("clean", "validate", "site");
-    private static final List<String> AVOID_AUTO_DEPOPULATE_PHASES = List.of("validate", "site");
+    private static final List<String> AVOID_AUTO_POPULATE_PHASES = Arrays.asList(new String[]{"clean", "validate", "site"});
+    private static final List<String> AVOID_AUTO_DEPOPULATE_PHASES = Arrays.asList(new String[]{"validate", "site"});
 
     private static final String DOCKER_VERSION_PLUGIN_GROUP_ID = "com.github.cafapi.plugins.docker.versions";
     private static final String DOCKER_VERSION_PLUGIN_ARTIFACT_ID = "docker-versions-maven-plugin";
@@ -61,13 +61,13 @@ public final class DockerVersionsLifecycleParticipant extends AbstractMavenLifec
 
         final List<String> sessionTasks = session.getRequest().getGoals();
 
-        if (sessionTasks == null || sessionTasks.isEmpty()) {
+        if (sessionTasks == null || sessionTasks.size() == 0) {
             LOGGER.debug("DockerVersionsLifecycleParticipant no tasks in session.");
             return;
         }
 
         final List<String> phasesInSession = getPhases(sessionTasks);
-        if (phasesInSession.isEmpty()) {
+        if (phasesInSession.size() == 0) {
             // Maven invoked with only goals, no lifecycle phases
             LOGGER.debug("DockerVersionsLifecycleParticipant no phases in session.");
             return;
@@ -124,7 +124,7 @@ public final class DockerVersionsLifecycleParticipant extends AbstractMavenLifec
                 continue;
             }
 
-            pluginConfigsToUpdate.add(Map.entry(plugin, pluginConfig));
+            pluginConfigsToUpdate.add(new AbstractMap.SimpleEntry<Plugin, Xpp3Dom>(plugin, pluginConfig));
         }
 
         if (pluginConfigsToUpdate.isEmpty() || pluginConfigsToUpdate.size() == 1) {

--- a/docker-versions-maven-plugin/src/test/java/com/github/cafapi/docker_versions/plugins/extension/test/DockerVersionsLifecycleParticipantTest.java
+++ b/docker-versions-maven-plugin/src/test/java/com/github/cafapi/docker_versions/plugins/extension/test/DockerVersionsLifecycleParticipantTest.java
@@ -15,6 +15,7 @@
  */
 package com.github.cafapi.docker_versions.plugins.extension.test;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
@@ -39,50 +40,50 @@ final class DockerVersionsLifecycleParticipantTest
     @Test
     public void testDisableAutoPopulate() throws Exception
     {
-        verifyDisableAutoPopulate(List.of("clean"));
-        verifyDisableAutoPopulate(List.of("validate"));
-        verifyDisableAutoPopulate(List.of("docker-versions:populate-project-registry"));
+        verifyDisableAutoPopulate(Arrays.asList(new String[]{"clean"}));
+        verifyDisableAutoPopulate(Arrays.asList(new String[]{"validate"}));
+        verifyDisableAutoPopulate(Arrays.asList(new String[]{"docker-versions:populate-project-registry"}));
 
-        verifyDisableAutoPopulate(List.of("clean", "validate"));
-        verifyDisableAutoPopulate(List.of("docker-versions:populate-project-registry", "validate"));
-        verifyDisableAutoPopulate(List.of("clean", "docker-versions:populate-project-registry"));
-        verifyDisableAutoPopulate(List.of("docker-versions:populate-project-registry", "verify"));
+        verifyDisableAutoPopulate(Arrays.asList(new String[]{"clean", "validate"}));
+        verifyDisableAutoPopulate(Arrays.asList(new String[]{"docker-versions:populate-project-registry", "validate"}));
+        verifyDisableAutoPopulate(Arrays.asList(new String[]{"clean", "docker-versions:populate-project-registry"}));
+        verifyDisableAutoPopulate(Arrays.asList(new String[]{"docker-versions:populate-project-registry", "verify"}));
 
-        verifyDisableAutoPopulate(List.of("clean", "validate", "docker-versions:populate-project-registry"));
-        verifyDisableAutoPopulate(List.of("clean", "validate", "docker-versions:depopulate-project-registry"));
-        verifyDisableAutoPopulate(List.of("clean", "docker-versions:depopulate-project-registry"));
-        verifyDisableAutoPopulate(List.of("docker-versions:depopulate-project-registry"));
-        verifyDisableAutoPopulate(List.of("validate", "docker-versions:depopulate-project-registry"));
+        verifyDisableAutoPopulate(Arrays.asList(new String[]{"clean", "validate", "docker-versions:populate-project-registry"}));
+        verifyDisableAutoPopulate(Arrays.asList(new String[]{"clean", "validate", "docker-versions:depopulate-project-registry"}));
+        verifyDisableAutoPopulate(Arrays.asList(new String[]{"clean", "docker-versions:depopulate-project-registry"}));
+        verifyDisableAutoPopulate(Arrays.asList(new String[]{"docker-versions:depopulate-project-registry"}));
+        verifyDisableAutoPopulate(Arrays.asList(new String[]{"validate", "docker-versions:depopulate-project-registry"}));
 
-        verifyDisableAutoPopulate(List.of("clean", "validate", "site"));
-        verifyDisableAutoPopulate(List.of("clean", "validate", "docker-versions:populate-project-registry", "install"));
-        verifyDisableAutoPopulate(List.of("clean", "docker-versions:populate-project-registry", "verify"));
-        verifyDisableAutoPopulate(List.of("validate", "docker-versions:populate-project-registry", "site"));
+        verifyDisableAutoPopulate(Arrays.asList(new String[]{"clean", "validate", "site"}));
+        verifyDisableAutoPopulate(Arrays.asList(new String[]{"clean", "validate", "docker-versions:populate-project-registry", "install"}));
+        verifyDisableAutoPopulate(Arrays.asList(new String[]{"clean", "docker-versions:populate-project-registry", "verify"}));
+        verifyDisableAutoPopulate(Arrays.asList(new String[]{"validate", "docker-versions:populate-project-registry", "site"}));
 
-        verifyDisableAutoPopulate(List.of("docker-versions:populate-project-registry", "install", "deploy"));
+        verifyDisableAutoPopulate(Arrays.asList(new String[]{"docker-versions:populate-project-registry", "install", "deploy"}));
 
-        verifyDisableAutoPopulate(List.of("clean", "compiler:compile"));
-        verifyDisableAutoPopulate(List.of("compiler:help"));
-        verifyDisableAutoPopulate(List.of("site"));
-        verifyDisableAutoPopulate(List.of("docker:build", "docker:start", "docker:stop"));
-        verifyDisableAutoPopulate(List.of("docker-versions:populate-project-registry", "docker:build", "verify"));
+        verifyDisableAutoPopulate(Arrays.asList(new String[]{"clean", "compiler:compile"}));
+        verifyDisableAutoPopulate(Arrays.asList(new String[]{"compiler:help"}));
+        verifyDisableAutoPopulate(Arrays.asList(new String[]{"site"}));
+        verifyDisableAutoPopulate(Arrays.asList(new String[]{"docker:build", "docker:start", "docker:stop"}));
+        verifyDisableAutoPopulate(Arrays.asList(new String[]{"docker-versions:populate-project-registry", "docker:build", "verify"}));
     }
 
     @Test
     public void testEnableAutoPopulate() throws Exception
     {
-        verifyEnableAutoPopulate(List.of("verify"));
+        verifyEnableAutoPopulate(Arrays.asList(new String[]{"verify"}));
 
-        verifyEnableAutoPopulate(List.of("install", "deploy"));
-        verifyEnableAutoPopulate(List.of("clean", "deploy"));
-        verifyEnableAutoPopulate(List.of("validate", "install"));
+        verifyEnableAutoPopulate(Arrays.asList(new String[]{"install", "deploy"}));
+        verifyEnableAutoPopulate(Arrays.asList(new String[]{"clean", "deploy"}));
+        verifyEnableAutoPopulate(Arrays.asList(new String[]{"validate", "install"}));
 
-        verifyEnableAutoPopulate(List.of("clean", "install", "docker-versions:depopulate-project-registry"));
+        verifyEnableAutoPopulate(Arrays.asList(new String[]{"clean", "install", "docker-versions:depopulate-project-registry"}));
 
-        verifyEnableAutoPopulate(List.of("compile", "install", "deploy"));
+        verifyEnableAutoPopulate(Arrays.asList(new String[]{"compile", "install", "deploy"}));
 
-        verifyEnableAutoPopulate(List.of("clean", "install", "deploy"));
-        verifyEnableAutoPopulate(List.of("validate", "install", "deploy"));
+        verifyEnableAutoPopulate(Arrays.asList(new String[]{"clean", "install", "deploy"}));
+        verifyEnableAutoPopulate(Arrays.asList(new String[]{"validate", "install", "deploy"}));
     }
 
     private static void verifyDisableAutoPopulate(final List<String> tasks)

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,9 @@
     <properties>
         <copyrightYear>2024</copyrightYear>
         <copyrightNotice>Copyright ${copyrightYear} Open Text.</copyrightNotice>
-        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.release>8</maven.compiler.release>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
     </properties>
 
     <modules>


### PR DESCRIPTION
Need to support Java 8 for using the plugin extension on [jdk8-maven](https://github.com/CAFapi/buildenv-jdk8-image) build containers. 
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=888096
