### PR TITLE
I949051: Update the correct image version

### DIFF
--- a/docker-versions-maven-plugin/src/main/java/com/github/cafapi/docker_versions/plugins/DockerVersionsHelper.java
+++ b/docker-versions-maven-plugin/src/main/java/com/github/cafapi/docker_versions/plugins/DockerVersionsHelper.java
@@ -86,17 +86,34 @@ public final class DockerVersionsHelper
             implicitProperties.put((String) entry.getKey(), (String) entry.getValue());
         });
 
+        // Update tags
+        final boolean updatedTags = setElement(pom, imagesConfig, implicitProperties, "tag");
+
+        // Update digests
+        pom.rewind();
+
+        final boolean updatedDigests = setElement(pom, imagesConfig, implicitProperties, "digest");
+
+        final boolean madeReplacement = updatedTags || updatedDigests;
+        LOGGER.debug("Completed image version updates in plugin configuration. Made {}replacements.", madeReplacement ? "" : "no ");
+        return madeReplacement;
+    }
+
+    private static boolean setElement(
+        final ModifiedPomXMLEventReader pom,
+        final List<Xpp3Dom> imagesConfig,
+        final Map<String, String> properties,
+        final String element)
+        throws XMLStreamException
+    {
         final Stack<String> stack = new Stack<>();
         String path = "";
 
-        boolean needsUpdate = false;
-        boolean madeReplacement = false;
-        boolean hasDigest = false;
-
         String repository = null;
         String targetRepository = null;
-        String newVersion = null;
-        String newDigest = null;
+        String newValue = null;
+
+        boolean madeReplacement = false;
 
         while (pom.hasNext()) {
             final XMLEvent event = pom.nextEvent();
@@ -108,81 +125,55 @@ public final class DockerVersionsHelper
 
                 if (IMAGE_CONFIG_MATCH_PATTERN.matcher(path).matches()) {
                     if ("repository".equals(elementName)) {
-                        repository = PomHelper.evaluate(pom.getElementText().trim(), implicitProperties);
+                        repository = PomHelper.evaluate(pom.getElementText().trim(), properties);
                         path = stack.pop();
                     } else if ("targetRepository".equals(elementName)) {
                         targetRepository = pom.getElementText().trim();
                         path = stack.pop();
-                    } else if ("tag".equals(elementName)) {
-                        final Optional<Xpp3Dom> repo = findRepository(repository, targetRepository, imagesConfig);
-                        if (!repo.isPresent()) {
-                            needsUpdate = false;
-                        } else {
-                            LOGGER.debug("Updating repo : {}", repository);
-                            needsUpdate = true;
-                            final Xpp3Dom repoToUpdate = repo.get();
-
-                            newVersion = repoToUpdate.getChild("tag").getValue();
-                            newDigest = repoToUpdate.getChild("digest").getValue();
-                            hasDigest = false;
-                        }
-                        if (needsUpdate) {
-                            pom.mark(0);
-                        }
-                    } else if (needsUpdate && "digest".equals(elementName)) {
-                        hasDigest = true;
+                    } else if (element.equals(elementName)) {
                         pom.mark(0);
                     }
                 }
             }
             if (event.isEndElement()) {
-                if (needsUpdate && IMAGE_CONFIG_MATCH_PATTERN.matcher(path).matches()) {
-                    if ("tag".equals(event.asEndElement().getName().getLocalPart())) {
+                if (IMAGE_CONFIG_MATCH_PATTERN.matcher(path).matches()) {
+                    if (element.equals(event.asEndElement().getName().getLocalPart())) {
                         pom.mark(1);
-                        if (pom.hasMark(0) && pom.hasMark(1)) {
-                            pom.replaceBetween(0, 1, newVersion);
-                            pom.clearMark(0);
-                            pom.clearMark(1);
-                            madeReplacement = true;
-                        }
-                    } else if ("digest".equals(event.asEndElement().getName().getLocalPart())) {
-                        pom.mark(1);
-                        if (pom.hasMark(0) && pom.hasMark(1)) {
-                            pom.replaceBetween(0, 1, newDigest);
-                            pom.clearMark(0);
-                            pom.clearMark(1);
-                            madeReplacement = true;
-                        }
                     }
                 }
                 if (IMAGE_MATCH_PATTERN.matcher(path).matches()) {
-                    if (needsUpdate && !hasDigest) {
-                        final StringBuffer builder = new StringBuffer("    <digest>");
-                        builder.append(newDigest).append("</digest>").append('\n');
-                        final int endTagLocation = event.asEndElement().getLocation().getColumnNumber();
-                        final String endTag = "</image>";
-                        final String endImageTag = endTagLocation <= 0
-                            ? endTag
-                            : StringUtils.leftPad(endTag, endTagLocation + endTag.length());
+                    // Update the digest if necessary
+                    final Optional<Xpp3Dom> repo = findRepository(repository, targetRepository, imagesConfig);
+                    if (repo.isPresent()) {
+                        final Xpp3Dom repoToUpdate = repo.get();
 
-                        builder.append(endImageTag);
-                        pom.replace(builder.toString());
+                        newValue = repoToUpdate.getChild(element).getValue();
+
+                        if (pom.hasMark(0) && pom.hasMark(1)) {
+                            LOGGER.debug("Updating {} for repo : {}", element, repository);
+                            pom.replaceBetween(0, 1, newValue);
+                            pom.clearMark(0);
+                            pom.clearMark(1);
+                        } else if ("digest".equals(element)) {
+                            LOGGER.debug("Setting digest for repo : {}", repository);
+                            final StringBuffer builder = new StringBuffer("    <digest>");
+                            builder.append(newValue).append("</digest>").append('\n');
+                            final int endTagLocation = event.asEndElement().getLocation().getColumnNumber();
+                            final String endTag = "</image>";
+                            final String endImageTag = endTagLocation <= 0
+                                ? endTag
+                                : StringUtils.leftPad(endTag, endTagLocation + endTag.length());
+
+                            builder.append(endImageTag);
+                            pom.replace(builder.toString());
+                        }
                         madeReplacement = true;
                     }
-                    needsUpdate = false;
                 }
                 path = stack.pop();
             }
         }
-        LOGGER.debug("Completed image version updates in plugin configuration. Made {}replacements.", madeReplacement ? "" : "no ");
         return madeReplacement;
-    }
-
-    public static Optional<Xpp3Dom> findRepository(final String repository, final List<Xpp3Dom> imagesConfig)
-    {
-        return imagesConfig.stream()
-            .filter(img -> img.getChild("repository").getValue().endsWith(repository))
-            .findFirst();
     }
 
     public static Optional<Xpp3Dom> findRepository(
@@ -190,7 +181,7 @@ public final class DockerVersionsHelper
         final String targetRepository,
         final List<Xpp3Dom> imagesConfig)
     {
-        LOGGER.info("Finding config with {} and {}...", repository, targetRepository);
+        LOGGER.debug("Finding config with repository {} and targetRepository {}...", repository, targetRepository);
         if (targetRepository == null) {
             return imagesConfig.stream()
                 .filter(img -> img.getChild("repository").getValue().endsWith(repository))

--- a/docker-versions-maven-plugin/src/main/java/com/github/cafapi/docker_versions/plugins/DockerVersionsHelper.java
+++ b/docker-versions-maven-plugin/src/main/java/com/github/cafapi/docker_versions/plugins/DockerVersionsHelper.java
@@ -111,7 +111,6 @@ public final class DockerVersionsHelper
 
         String repository = null;
         String targetRepository = null;
-        String newValue = null;
 
         boolean madeReplacement = false;
 
@@ -147,7 +146,7 @@ public final class DockerVersionsHelper
                     if (repo.isPresent()) {
                         final Xpp3Dom repoToUpdate = repo.get();
 
-                        newValue = repoToUpdate.getChild(element).getValue();
+                        final String newValue = repoToUpdate.getChild(element).getValue();
 
                         if (pom.hasMark(0) && pom.hasMark(1)) {
                             LOGGER.debug("Updating {} for repo : {}", element, repository);

--- a/docker-versions-maven-plugin/src/main/java/com/github/cafapi/docker_versions/plugins/UseLatestReleasesMojo.java
+++ b/docker-versions-maven-plugin/src/main/java/com/github/cafapi/docker_versions/plugins/UseLatestReleasesMojo.java
@@ -113,7 +113,8 @@ public final class UseLatestReleasesMojo extends DockerVersionsUpdaterMojo
             final String staticTag = getLatestStaticTag(authToken, registrySchema.getSchema(), imageMoniker, latestTag, latestDigest);
 
             final Xpp3Dom imageToUpdate
-                = DockerVersionsHelper.findRepository(imageMoniker.getRepositoryFromConfigSansRegistry(), imagesConfig)
+                = DockerVersionsHelper.findRepository(
+                    imageMoniker.getRepositoryFromConfigSansRegistry(), imageConfig.getTargetRepository(), imagesConfig)
                     .orElseThrow(()
                         -> new IllegalArgumentException("Image configuration not found '" + imageMoniker.getFullImageNameWithoutTag()));
 

--- a/docker-versions-maven-plugin/src/test/java/com/github/cafapi/docker_versions/plugins/test/DockerVersionsHelperTest.java
+++ b/docker-versions-maven-plugin/src/test/java/com/github/cafapi/docker_versions/plugins/test/DockerVersionsHelperTest.java
@@ -74,6 +74,78 @@ final class DockerVersionsHelperTest
         Assertions.assertTrue(madeReplacement, "Pom file was updated");
     }
 
+    @Test
+    public void testSetImageVersionSameRepo() throws XMLStreamException, URISyntaxException, IOException
+    {
+        final URL pomUrl = DockerVersionsHelperTest.class.getResource("testSameRepoPluginPom.xml");
+        final File pomFile = new File(pomUrl.toURI());
+        final StringBuilder input = DockerVersionsHelper.readFile(pomFile);
+        final ModifiedPomXMLEventReader pomToUpdate = DockerVersionsHelper.createPomXmlEventReader(input, pomFile.getAbsolutePath());
+
+        final List<Xpp3Dom> imagesConfig = new ArrayList<>();
+        imagesConfig.add(createImage(
+            "dockerhub-public.artifactory.acme.net/jobservice/job-service-postgres",
+            "jobservice/job-service-postgres-liquibase",
+            "3.5",
+            "3.5.0",
+            "sha256:676c166c8749f81c07d0e24ec6528fd8b5f3950514d9f29e6514cad64b1c0dc3"));
+        imagesConfig.add(createImage(
+            "dockerhub-public.artifactory.acme.net/jobservice/job-service-postgres",
+            "jobservice/job-service-postgres-flyway",
+            "7.0",
+            "7.0.2",
+            "sha256:676c166c8749f81c07d0e24ec6528fd8b5f3950514d9f29e6514cad64b1c0dc3"));
+
+        final Properties properties = new Properties();
+        properties.load(DockerVersionsHelperTest.class.getResourceAsStream("test.properties"));
+
+        final boolean madeReplacement = DockerVersionsHelper.setImageVersion(pomToUpdate, imagesConfig, properties);
+
+        LOGGER.info("Updated pom : {}", pomToUpdate.asStringBuilder());
+
+        Assertions.assertTrue(madeReplacement, "Pom file was updated");
+    }
+
+    @Test
+    public void testSetImageVersionMixedRepos() throws XMLStreamException, URISyntaxException, IOException
+    {
+        final URL pomUrl = DockerVersionsHelperTest.class.getResource("testSameRepoPluginPom.xml");
+        final File pomFile = new File(pomUrl.toURI());
+        final StringBuilder input = DockerVersionsHelper.readFile(pomFile);
+        final ModifiedPomXMLEventReader pomToUpdate = DockerVersionsHelper.createPomXmlEventReader(input, pomFile.getAbsolutePath());
+
+        final List<Xpp3Dom> imagesConfig = new ArrayList<>();
+        imagesConfig.add(createImage(
+            "dockerhub-public.artifactory.acme.net/jobservice/job-service-postgres",
+            "jobservice/job-service-postgres-liquibase",
+            "3.5",
+            "3.5.0",
+            "sha256:676c166c8749f81c07d0e24ec6528fd8b5f3950514d9f29e6514cad64b1c0dc3"));
+        imagesConfig.add(createImage(
+            "dockerhub-public.artifactory.acme.net/cafapi/opensuse-jre17",
+            "1.5.0",
+            "sha256:6308e00f71d9c3fe6b5181aafe08abe72824301fd917887b8b644436f0de9740"));
+        imagesConfig.add(createImage(
+            "dockerhub-public.artifactory.acme.net/jobservice/job-service-postgres",
+            "jobservice/job-service-postgres-flyway",
+            "7.0",
+            "7.0.2",
+            "sha256:676c166c8749f81c07d0e24ec6528fd8b5f3950514d9f29e6514cad64b1c0dc3"));
+        imagesConfig.add(createImage(
+            "dockerhub-public.artifactory.acme.net/cafapi/opensuse-jre8",
+            "3.10.0",
+            "sha256:7fb9a3aecb3e8112e61569f5510a602b9a18a5712c5e90497f77feaedec2c66c"));
+
+        final Properties properties = new Properties();
+        properties.load(DockerVersionsHelperTest.class.getResourceAsStream("test.properties"));
+
+        final boolean madeReplacement = DockerVersionsHelper.setImageVersion(pomToUpdate, imagesConfig, properties);
+
+        LOGGER.info("Updated pom : {}", pomToUpdate.asStringBuilder());
+
+        Assertions.assertTrue(madeReplacement, "Pom file was updated");
+    }
+
     private static Xpp3Dom createImage(final String repository, final String tag, final String digest)
     {
         final Xpp3Dom image = new Xpp3Dom("image");
@@ -94,4 +166,36 @@ final class DockerVersionsHelperTest
         return image;
     }
 
+    private static Xpp3Dom createImage(
+        final String repository,
+        final String targetRepository,
+        final String tag,
+        final String latestTag,
+        final String digest)
+    {
+        final Xpp3Dom image = new Xpp3Dom("image");
+
+        final Xpp3Dom repoElm = new Xpp3Dom("repository");
+        repoElm.setValue(repository);
+
+        final Xpp3Dom targetRepoElm = new Xpp3Dom("targetRepository");
+        targetRepoElm.setValue(targetRepository);
+
+        final Xpp3Dom tagElm = new Xpp3Dom("tag");
+        tagElm.setValue(tag);
+
+        final Xpp3Dom latestTagElm = new Xpp3Dom("latestTag");
+        latestTagElm.setValue(latestTag);
+
+        final Xpp3Dom digestElm = new Xpp3Dom("digest");
+        digestElm.setValue(digest);
+
+        image.addChild(repoElm);
+        image.addChild(targetRepoElm);
+        image.addChild(tagElm);
+        image.addChild(latestTagElm);
+        image.addChild(digestElm);
+
+        return image;
+    }
 }

--- a/docker-versions-maven-plugin/src/test/java/com/github/cafapi/docker_versions/plugins/test/DockerVersionsHelperTest.java
+++ b/docker-versions-maven-plugin/src/test/java/com/github/cafapi/docker_versions/plugins/test/DockerVersionsHelperTest.java
@@ -146,6 +146,46 @@ final class DockerVersionsHelperTest
         Assertions.assertTrue(madeReplacement, "Pom file was updated");
     }
 
+    @Test
+    public void testSetImageVersionCheckOrder() throws XMLStreamException, URISyntaxException, IOException
+    {
+        final URL pomUrl = DockerVersionsHelperTest.class.getResource("testCheckOrderPluginPom.xml");
+        final File pomFile = new File(pomUrl.toURI());
+        final StringBuilder input = DockerVersionsHelper.readFile(pomFile);
+        final ModifiedPomXMLEventReader pomToUpdate = DockerVersionsHelper.createPomXmlEventReader(input, pomFile.getAbsolutePath());
+
+        final List<Xpp3Dom> imagesConfig = new ArrayList<>();
+        imagesConfig.add(createImage(
+            "dockerhub-public.artifactory.acme.net/jobservice/job-service-postgres",
+            "jobservice/job-service-postgres-liquibase",
+            "3.5",
+            "3.5.0",
+            "sha256:5323cd5945f90795e6448480b8cc622a9472b76f93c0eb97510ca15058e7b337"));
+        imagesConfig.add(createImage(
+            "dockerhub-public.artifactory.acme.net/cafapi/opensuse-jre17",
+            "1.5.0",
+            "sha256:6308e00f71d9c3fe6b5181aafe08abe72824301fd917887b8b644436f0de9740"));
+        imagesConfig.add(createImage(
+            "dockerhub-public.artifactory.acme.net/jobservice/job-service-postgres",
+            "jobservice/job-service-postgres-flyway",
+            "7.0",
+            "7.0.2",
+            "sha256:676c166c8749f81c07d0e24ec6528fd8b5f3950514d9f29e6514cad64b1c0dc3"));
+        imagesConfig.add(createImage(
+            "dockerhub-public.artifactory.acme.net/cafapi/opensuse-jre8",
+            "3.10.0",
+            "sha256:7fb9a3aecb3e8112e61569f5510a602b9a18a5712c5e90497f77feaedec2c66c"));
+
+        final Properties properties = new Properties();
+        properties.load(DockerVersionsHelperTest.class.getResourceAsStream("test.properties"));
+
+        final boolean madeReplacement = DockerVersionsHelper.setImageVersion(pomToUpdate, imagesConfig, properties);
+
+        LOGGER.info("Updated pom : {}", pomToUpdate.asStringBuilder());
+
+        Assertions.assertTrue(madeReplacement, "Pom file was updated");
+    }
+
     private static Xpp3Dom createImage(final String repository, final String tag, final String digest)
     {
         final Xpp3Dom image = new Xpp3Dom("image");

--- a/docker-versions-maven-plugin/src/test/resources/com/github/cafapi/docker_versions/plugins/test/testCheckOrderPluginPom.xml
+++ b/docker-versions-maven-plugin/src/test/resources/com/github/cafapi/docker_versions/plugins/test/testCheckOrderPluginPom.xml
@@ -65,8 +65,8 @@
                                 <digest>sha256:8f4cb0832ac99c1163decdbd446b367e4a90a5e6380e2b0429d0273013968b38</digest>
                             </image>
                             <image>
-                                <repository>${dockerHubPublic}/cafapi/opensuse-jre17</repository>
                                 <tag>1.4.3</tag>
+                                <repository>${dockerHubPublic}/cafapi/opensuse-jre17</repository>
                                 <digest>sha256:76b8dc916151a5ede5d8a999fcd0929ca3cd3a9dbf67085f65ef98b5279359f4</digest>
                             </image>
                             <image>
@@ -74,16 +74,16 @@
                                 <tag>3.9.3</tag>
                             </image>
                             <image>
-                                <repository>${dockerHubPublic}/jobservice/job-service-postgres</repository>
-                                <targetRepository>jobservice/job-service-postgres-liquibase</targetRepository>
-                                <tag>3.5.0</tag>
                                 <latestTag>3.5.0</latestTag>
+                                <repository>${dockerHubPublic}/jobservice/job-service-postgres</repository>
+                                <tag>3.5.0</tag>
+                                <targetRepository>jobservice/job-service-postgres-liquibase</targetRepository>
                                 <digest>sha256:5323cd5945f90795e6448480b8cc622a9472b76f93c0eb97510ca15058e7b337</digest>
                             </image>
                             <image>
-                                <repository>${dockerHubPublic}/jobservice/job-service-postgres</repository>
                                 <targetRepository>jobservice/job-service-postgres-flyway</targetRepository>
                                 <tag>7.0.2</tag>
+                                <repository>${dockerHubPublic}/jobservice/job-service-postgres</repository>
                                 <latestTag>7.0.2</latestTag>
                                 <digest>sha256:676c166c8749f81c07d0e24ec6528fd8b5f3950514d9f29e6514cad64b1c0dc3</digest>
                             </image>

--- a/docker-versions-maven-plugin/src/test/resources/com/github/cafapi/docker_versions/plugins/test/testSameRepoPluginPom.xml
+++ b/docker-versions-maven-plugin/src/test/resources/com/github/cafapi/docker_versions/plugins/test/testSameRepoPluginPom.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2024 Open Text.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.acme.versions</groupId>
+    <artifactId>acme-versions</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <corporateRepositoryManager>artifactory.acme.net</corporateRepositoryManager>
+        <homeDockerPrereleaseRegistry>acme-docker-prerelease.${corporateRepositoryManager}</homeDockerPrereleaseRegistry>
+        <homeDockerReleaseRegistry>acme-docker-release.${corporateRepositoryManager}</homeDockerReleaseRegistry>
+        <snapshotTag>SNAPSHOT</snapshotTag>
+        <viewServiceBaseImage>${homeDockerPrereleaseRegistry}/apollo/view-service-base</viewServiceBaseImage>
+    </properties>
+
+    <modules>
+        <module>acme-versions-maven-plugin</module>
+        <module>acme-versions-maven-plugin-usage</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.github.docker-java</groupId>
+                <artifactId>docker-java-api</artifactId>
+                <version>3.3.6</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>com.github.cafapi.plugins.docker.versions</groupId>
+                    <artifactId>docker-versions-maven-plugin</artifactId>
+                    <version>1.0.0-SNAPSHOT</version>
+                    <configuration>
+                        <imageManagement>
+                            <image>
+                                <repository>${homeDockerReleaseRegistry}/caf/search-and-analytics</repository>
+                                <tag>8.1.0</tag>
+                                <digest>sha256:8f4cb0832ac99c1163decdbd446b367e4a90a5e6380e2b0429d0273013968b38</digest>
+                            </image>
+                            <image>
+                                <repository>${dockerHubPublic}/cafapi/opensuse-jre17</repository>
+                                <tag>1.4.3</tag>
+                                <digest>sha256:76b8dc916151a5ede5d8a999fcd0929ca3cd3a9dbf67085f65ef98b5279359f4</digest>
+                            </image>
+                            <image>
+                                <repository>${dockerHubPublic}/cafapi/opensuse-jre8</repository>
+                                <tag>3.9.3</tag>
+                            </image>
+                            <image>
+                                <repository>${dockerHubPublic}/jobservice/job-service-postgres</repository>
+                                <targetRepository>jobservice/job-service-postgres-liquibase</targetRepository>
+                                <tag>3.5.0</tag>
+                                <latestTag>3.5.0</latestTag>
+                                <digest>sha256:676c166c8749f81c07d0e24ec6528fd8b5f3950514d9f29e6514cad64b1c0dc3</digest>
+                            </image>
+                            <image>
+                                <repository>${dockerHubPublic}/jobservice/job-service-postgres</repository>
+                                <targetRepository>jobservice/job-service-postgres-flyway</targetRepository>
+                                <tag>7.0.2</tag>
+                                <latestTag>7.0.2</latestTag>
+                                <digest>sha256:676c166c8749f81c07d0e24ec6528fd8b5f3950514d9f29e6514cad64b1c0dc3</digest>
+                            </image>
+                        </imageManagement>
+                        <ignoreVersions>
+                            <ignoreVersion>
+                                <type>regex</type>
+                                <version>(?i).*alpha.*</version>
+                            </ignoreVersion>
+                            <ignoreVersion>
+                                <type>regex</type>
+                                <version>(?i).*beta.*</version>
+                            </ignoreVersion>
+                        </ignoreVersions>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=949051

- Identify image configuration to update based on both `<repository>` and `<targetRepository>` values.
- Make 2 passes of the pom to update tag and digest. Implementation incorrectly assumed that the elements of the `<image>` tag were in a certain order and would not update the correct `<tag>` and `<digest>` values.