### PR TITLE
D1200007: Extra image pull status logging

### DIFF
--- a/docker-versions-maven-plugin/src/main/java/com/github/cafapi/docker_versions/docker/client/DockerRestClient.java
+++ b/docker-versions-maven-plugin/src/main/java/com/github/cafapi/docker_versions/docker/client/DockerRestClient.java
@@ -110,13 +110,16 @@ public final class DockerRestClient
 
             private static final double ONE_GB = 1_000_000_000.0;
             private static final double ONE_MB = 1_000_000.0;
-            private final Map<String, Long> itemBytes = new ConcurrentHashMap<>();
-            private final Map<String, Long> totalBytes = new ConcurrentHashMap<>();
-            private final Set<String> countedItems = ConcurrentHashMap.newKeySet();
-            private final Set<String> loggedItems = ConcurrentHashMap.newKeySet();
-            private final Map<String, String> lastStatusByItem = new ConcurrentHashMap<>();
-            private final AtomicLong knownTotalBytesExpected = new AtomicLong(0L);
-            private final AtomicInteger pullPercentage = new AtomicInteger(0);
+
+            private final Map<String, Long> downloadedPerLayer = new ConcurrentHashMap<>();
+            private final Map<String, Long> layerSizes = new ConcurrentHashMap<>();
+            private final Set<String> registeredLayers = ConcurrentHashMap.newKeySet();
+            private final Set<String> announcedLayers = ConcurrentHashMap.newKeySet();
+            private final Set<String> downloadCompleteLayers = ConcurrentHashMap.newKeySet();
+            private final Set<String> pullCompleteLayers = ConcurrentHashMap.newKeySet();
+            private final Map<String, String> lastStatusPerLayer = new ConcurrentHashMap<>();
+            private final AtomicLong aggregateExpectedBytes = new AtomicLong(0L);
+            private final AtomicInteger lastLoggedMilestone = new AtomicInteger(0);
 
             @Override
             public void onError(final Throwable throwable) {
@@ -126,36 +129,43 @@ public final class DockerRestClient
 
             /**
              * This method logs pull progress when images are pulled from docker.
-             * @param item the pull response item containing the status and progress information
+             * @param item the progress item reported by the docker daemon
              */
             @Override
             public void onNext(final PullResponseItem item) {
                 super.onNext(item);
 
                 final String status = item.getStatus();
+                final String layerId = item.getId();
+
                 if (status == null) {
                     return;
                 }
-
                 // Image-level messages (Digest, Status) have no layer ID
-                if (item.getId() == null) {
+                if (layerId == null) {
                     LOGGER.info("{}", status);
                     return;
                 }
 
-                final String itemId = item.getId();
-
-                // Log layer statuses that don't carry progress detail
                 if ("Already exists".equalsIgnoreCase(status)) {
-                    LOGGER.info("{}: Already exists", itemId);
+                    if (announcedLayers.add(layerId)) {
+                        LOGGER.info("{}: Already exists.", layerId);
+                    }
                     return;
                 }
-                if ("Pull complete".equalsIgnoreCase(status)) {
-                    LOGGER.info("{}: Pull complete", itemId);
-                    return;
-                }
+
                 if ("Download complete".equalsIgnoreCase(status)) {
-                    LOGGER.info("{}: Download complete", itemId);
+                    if (downloadCompleteLayers.add(layerId)) {
+                        LOGGER.info("{}: Download complete", layerId);
+                    }
+                    return;
+                }
+
+                if ("Pull complete".equalsIgnoreCase(status)) {
+                    // The layer has been fully downloaded and extracted, and is now ready to be used by the Docker daemon.
+                    if (pullCompleteLayers.add(layerId)) {
+                        LOGGER.info("{}: Pull complete", layerId);
+                    }
                     return;
                 }
 
@@ -164,44 +174,51 @@ public final class DockerRestClient
                 }
 
                 final ResponseItem.ProgressDetail progressDetail = item.getProgressDetail();
-                final String previous = lastStatusByItem.get(itemId);
-                lastStatusByItem.put(itemId, status);
-                final Long itemCurrent = Optional.ofNullable(progressDetail.getCurrent()).orElse(0L);
-                final Long itemTotal = Optional.ofNullable(progressDetail.getTotal()).orElse(0L);
+                final String previousStatus = lastStatusPerLayer.get(layerId);
+                lastStatusPerLayer.put(layerId, status);
+                final long layerDownloaded = Optional.ofNullable(progressDetail.getCurrent()).orElse(0L);
+                final long layerSize = Optional.ofNullable(progressDetail.getTotal()).orElse(0L);
 
                 if ("Extracting".equalsIgnoreCase(status)) {
-                    if (!"Extracting".equalsIgnoreCase(previous)) {
-                        final long layerSize = totalBytes.getOrDefault(itemId, 0L);
-                        LOGGER.info("{}: Extracting ({})", itemId, stringifyBytes(layerSize));
+                    // The compressed layer archive has finished downloading and is now being unzipped and written onto local disk.
+                    if (!"Extracting".equalsIgnoreCase(previousStatus)) {
+                        LOGGER.info("{}: Extracting ({})", layerId, stringifyBytes(layerSizes.getOrDefault(layerId, 0L)));
                     }
                 } else if ("Downloading".equalsIgnoreCase(status)) {
-                    if (itemCurrent > 0) {
-                        itemBytes.put(itemId, itemCurrent);
+                    // Compressed layer file is actively being transferred over the network from the container registry
+                    // (e.g., Docker Hub, ECR, GHCR) to local host machine.
+                    if (layerDownloaded > 0) {
+                        downloadedPerLayer.put(layerId, layerDownloaded);
                     }
 
-                    if (itemTotal > 0 && countedItems.add(itemId)) {
-                        totalBytes.put(itemId, itemTotal);
-                        knownTotalBytesExpected.addAndGet(itemTotal);
-                        pullPercentage.set(0);
+                    // Add to aggregate total only on first progress for this layer
+                    if (layerSize > 0 && registeredLayers.add(layerId)) {
+                        layerSizes.put(layerId, layerSize);
+                        aggregateExpectedBytes.addAndGet(layerSize);
                     }
 
-                    final long bytesDownloaded = itemBytes.values().stream().mapToLong(Long::longValue).sum();
-                    if (knownTotalBytesExpected.get() > 0) {
-                        final int percent = (int) Math.round(bytesDownloaded * 100.0 / knownTotalBytesExpected.get());
-                        final int progress = (percent / 10) * 10;
-                        if (LOGGER.isInfoEnabled() && progress > pullPercentage.get()) {
-                            pullPercentage.set(progress);
-                            LOGGER.info("{}: Downloading: {}% complete, {} of {} ({} layer{})",
-                                itemId,
-                                progress,
-                                stringifyBytes(bytesDownloaded),
-                                stringifyBytes(knownTotalBytesExpected.get()),
-                                countedItems.size(),
-                                countedItems.size() > 1 ? "s" : "");
+                    final long totalDownloaded = downloadedPerLayer.values().stream().mapToLong(Long::longValue).sum();
+                    if (aggregateExpectedBytes.get() > 0) {
+                        final int percent = (int) Math.round(totalDownloaded * 100.0 / aggregateExpectedBytes.get());
+                        final int milestone = (percent / 10) * 10;
+                        if (LOGGER.isInfoEnabled() && milestone > lastLoggedMilestone.get()) {
+                            lastLoggedMilestone.set(milestone);
+                            // Fall back to this layer's own (possibly zero) size when it hasn't been recorded yet, e.g.
+                            // when a registry omits the size on a layer's very first progress event.
+                            final long knownLayerSize = layerSizes.getOrDefault(layerId, layerSize);
+                            LOGGER.info("{}: Downloading ({}), {}% complete, {}/{} ({} layer{})",
+                                layerId,
+                                stringifyBytes(knownLayerSize),
+                                milestone,
+                                stringifyBytes(totalDownloaded),
+                                stringifyBytes(aggregateExpectedBytes.get()),
+                                registeredLayers.size(),
+                                (registeredLayers.size() > 1) ? "s" : "");
                         }
                     }
-                    if (loggedItems.add(itemId)) {
-                        LOGGER.info("{}: Downloading ({})", itemId, stringifyBytes(itemTotal));
+                    if (announcedLayers.add(layerId)) {
+                        // Ensures each layer is logged at least once with its size
+                        LOGGER.info("{}: Pulling {}", layerId, stringifyBytes(layerSize));
                     }
                 }
             }
@@ -211,12 +228,10 @@ public final class DockerRestClient
                 final long elapsedMs = (System.nanoTime() - startTime) / 1_000_000;
                 LOGGER.info("Done pulling {}:{} in {}.{}s",
                     repository, tag, elapsedMs / 1000, String.format("%03d", elapsedMs % 1000));
-                lastStatusByItem.clear(); // Clear all remaining layer tracking data
                 super.onComplete();
             }
 
-            private String stringifyBytes(final long bytes)
-            {
+            private String stringifyBytes(final long bytes) {
                 if (bytes >= ONE_GB) {
                     return String.format("%.2fGB", (bytes / ONE_GB));
                 } else if (bytes >= ONE_MB) {

--- a/docker-versions-maven-plugin/src/main/java/com/github/cafapi/docker_versions/docker/client/DockerRestClient.java
+++ b/docker-versions-maven-plugin/src/main/java/com/github/cafapi/docker_versions/docker/client/DockerRestClient.java
@@ -154,10 +154,6 @@ public final class DockerRestClient
                     LOGGER.info("{}: Pull complete", itemId);
                     return;
                 }
-                if ("Verifying Checksum".equalsIgnoreCase(status)) {
-                    LOGGER.debug("{}: Verifying Checksum", itemId);
-                    return;
-                }
                 if ("Download complete".equalsIgnoreCase(status)) {
                     LOGGER.info("{}: Download complete", itemId);
                     return;
@@ -195,7 +191,8 @@ public final class DockerRestClient
                         final int progress = (percent / 10) * 10;
                         if (LOGGER.isInfoEnabled() && progress > pullPercentage.get()) {
                             pullPercentage.set(progress);
-                            LOGGER.info("Downloading: {}% complete, {} of {} ({} layer{})",
+                            LOGGER.info("{}: Downloading: {}% complete, {} of {} ({} layer{})",
+                                itemId,
                                 progress,
                                 stringifyBytes(bytesDownloaded),
                                 stringifyBytes(knownTotalBytesExpected.get()),
@@ -209,14 +206,23 @@ public final class DockerRestClient
                 }
             }
 
+            @Override
+            public void onComplete() {
+                final long elapsedMs = (System.nanoTime() - startTime) / 1_000_000;
+                LOGGER.info("Done pulling {}:{} in {}.{}s",
+                    repository, tag, elapsedMs / 1000, String.format("%03d", elapsedMs % 1000));
+                lastStatusByItem.clear(); // Clear all remaining layer tracking data
+                super.onComplete();
+            }
+
             private String stringifyBytes(final long bytes)
             {
                 if (bytes >= ONE_GB) {
-                    return String.format("%.2f GB", (bytes / ONE_GB));
+                    return String.format("%.2fGB", (bytes / ONE_GB));
                 } else if (bytes >= ONE_MB) {
-                    return String.format("%.2f MB", (bytes / ONE_MB));
+                    return String.format("%.2fMB", (bytes / ONE_MB));
                 }
-                return bytes + " bytes";
+                return bytes + "bytes";
             }
         };
 
@@ -224,10 +230,6 @@ public final class DockerRestClient
             .withTag(tag)
             .exec(callback)
             .awaitCompletion();
-
-        final long elapsedMs = (System.nanoTime() - startTime) / 1_000_000;
-        LOGGER.info("Pull complete for {}:{} in {}.{}s",
-            repository, tag, elapsedMs / 1000, String.format("%03d", elapsedMs % 1000));
     }
 
     public void tagImage(

--- a/docker-versions-maven-plugin/src/main/java/com/github/cafapi/docker_versions/docker/client/DockerRestClient.java
+++ b/docker-versions-maven-plugin/src/main/java/com/github/cafapi/docker_versions/docker/client/DockerRestClient.java
@@ -99,7 +99,6 @@ public final class DockerRestClient
     ) throws InterruptedException
     {
         LOGGER.info("Pulling {}:{}...", repository, tag);
-        final long startTime = System.nanoTime();
         final PullImageCmd pullCommand = dockerClient.pullImageCmd(repository);
 
         if (authConfig != null) {
@@ -221,14 +220,6 @@ public final class DockerRestClient
                         LOGGER.info("{}: Pulling {}", layerId, stringifyBytes(layerSize));
                     }
                 }
-            }
-
-            @Override
-            public void onComplete() {
-                final long elapsedMs = (System.nanoTime() - startTime) / 1_000_000;
-                LOGGER.info("Done pulling {}:{} in {}.{}s",
-                    repository, tag, elapsedMs / 1000, String.format("%03d", elapsedMs % 1000));
-                super.onComplete();
             }
 
             private String stringifyBytes(final long bytes) {

--- a/docker-versions-maven-plugin/src/main/java/com/github/cafapi/docker_versions/docker/client/DockerRestClient.java
+++ b/docker-versions-maven-plugin/src/main/java/com/github/cafapi/docker_versions/docker/client/DockerRestClient.java
@@ -99,6 +99,7 @@ public final class DockerRestClient
     ) throws InterruptedException
     {
         LOGGER.info("Pulling {}:{}...", repository, tag);
+        final long startTime = System.nanoTime();
         final PullImageCmd pullCommand = dockerClient.pullImageCmd(repository);
 
         if (authConfig != null) {
@@ -132,54 +133,78 @@ public final class DockerRestClient
                 super.onNext(item);
 
                 final String status = item.getStatus();
+                if (status == null) {
+                    return;
+                }
 
-                if (item.getId() != null && item.getProgressDetail() != null) {
-                    final String itemId = item.getId();
-                    final ResponseItem.ProgressDetail progressDetail = item.getProgressDetail();
-                    final String previous = lastStatusByItem.get(itemId);
-                    lastStatusByItem.put(itemId, status);
-                    final Long itemCurrent = Optional.ofNullable(progressDetail.getCurrent()).orElse(0L);
-                    final Long itemTotal = Optional.ofNullable(progressDetail.getTotal()).orElse(0L);
-                    if ("Extracting".equalsIgnoreCase(status)) {
-                        final long pulledBytes = totalBytes.getOrDefault(itemId, 0L);
-                        if (!"Extracting".equalsIgnoreCase(previous)) {
-                            LOGGER.info("Extracting {} ({})", itemId, stringifyBytes(pulledBytes));
-                        }
-                        return;
-                    } else if ("Downloading".equalsIgnoreCase(status)) {
-                        if (itemCurrent > 0) {
-                            itemBytes.put(itemId, itemCurrent);
-                        }
+                // Image-level messages (Digest, Status) have no layer ID
+                if (item.getId() == null) {
+                    LOGGER.info("{}", status);
+                    return;
+                }
 
-                        // Add to aggregate total only on first progress for this item
-                        if (itemTotal > 0 && countedItems.add(itemId)) {
-                            totalBytes.put(itemId, itemTotal);
-                            knownTotalBytesExpected.addAndGet(itemTotal);
-                            // If a new item is received pull percentage is now invalid.
-                            pullPercentage.set(0);
-                        }
+                final String itemId = item.getId();
 
-                        final long bytesDownloaded = itemBytes.values().stream().mapToLong(Long::longValue).sum();
-                        if (knownTotalBytesExpected.get() > 0) {
-                            final int percent = (int) Math.round(bytesDownloaded * 100.0 / knownTotalBytesExpected.get());
-                            final int progress = (percent / 10) * 10;
-                            if (LOGGER.isInfoEnabled() && progress > pullPercentage.get()) {
-                                pullPercentage.set(progress);
-                                LOGGER.info("Pulling {} ({}) {}% of {} item{} completed, {} of {}",
-                                    itemId,
-                                    stringifyBytes(totalBytes.get(itemId)),
-                                    progress,
-                                    countedItems.size(),
-                                    (countedItems.size() > 1)?"s":"",
-                                    stringifyBytes(bytesDownloaded),
-                                    stringifyBytes(knownTotalBytesExpected.get()));
-                                loggedItems.add(itemId);
-                            }
+                // Log layer statuses that don't carry progress detail
+                if ("Already exists".equalsIgnoreCase(status)) {
+                    LOGGER.info("{}: Already exists", itemId);
+                    return;
+                }
+                if ("Pull complete".equalsIgnoreCase(status)) {
+                    LOGGER.info("{}: Pull complete", itemId);
+                    return;
+                }
+                if ("Verifying Checksum".equalsIgnoreCase(status)) {
+                    LOGGER.debug("{}: Verifying Checksum", itemId);
+                    return;
+                }
+                if ("Download complete".equalsIgnoreCase(status)) {
+                    LOGGER.info("{}: Download complete", itemId);
+                    return;
+                }
+
+                if (item.getProgressDetail() == null) {
+                    return;
+                }
+
+                final ResponseItem.ProgressDetail progressDetail = item.getProgressDetail();
+                final String previous = lastStatusByItem.get(itemId);
+                lastStatusByItem.put(itemId, status);
+                final Long itemCurrent = Optional.ofNullable(progressDetail.getCurrent()).orElse(0L);
+                final Long itemTotal = Optional.ofNullable(progressDetail.getTotal()).orElse(0L);
+
+                if ("Extracting".equalsIgnoreCase(status)) {
+                    if (!"Extracting".equalsIgnoreCase(previous)) {
+                        final long layerSize = totalBytes.getOrDefault(itemId, 0L);
+                        LOGGER.info("{}: Extracting ({})", itemId, stringifyBytes(layerSize));
+                    }
+                } else if ("Downloading".equalsIgnoreCase(status)) {
+                    if (itemCurrent > 0) {
+                        itemBytes.put(itemId, itemCurrent);
+                    }
+
+                    if (itemTotal > 0 && countedItems.add(itemId)) {
+                        totalBytes.put(itemId, itemTotal);
+                        knownTotalBytesExpected.addAndGet(itemTotal);
+                        pullPercentage.set(0);
+                    }
+
+                    final long bytesDownloaded = itemBytes.values().stream().mapToLong(Long::longValue).sum();
+                    if (knownTotalBytesExpected.get() > 0) {
+                        final int percent = (int) Math.round(bytesDownloaded * 100.0 / knownTotalBytesExpected.get());
+                        final int progress = (percent / 10) * 10;
+                        if (LOGGER.isInfoEnabled() && progress > pullPercentage.get()) {
+                            pullPercentage.set(progress);
+                            LOGGER.info("Downloading: {}% complete, {} of {} ({} layer{})",
+                                progress,
+                                stringifyBytes(bytesDownloaded),
+                                stringifyBytes(knownTotalBytesExpected.get()),
+                                countedItems.size(),
+                                countedItems.size() > 1 ? "s" : "");
                         }
-                        if (loggedItems.add(itemId)) {
-                            // Ensures each item is logged at least once with its size
-                            LOGGER.info("Pulling {} ({})", itemId, stringifyBytes(itemTotal));
-                        }
+                    }
+                    if (loggedItems.add(itemId)) {
+                        LOGGER.info("{}: Downloading ({})", itemId, stringifyBytes(itemTotal));
                     }
                 }
             }
@@ -187,11 +212,11 @@ public final class DockerRestClient
             private String stringifyBytes(final long bytes)
             {
                 if (bytes >= ONE_GB) {
-                    return String.format("%.2fGB",  (bytes / ONE_GB));
+                    return String.format("%.2f GB", (bytes / ONE_GB));
                 } else if (bytes >= ONE_MB) {
-                    return String.format("%.2fMB",  (bytes / ONE_MB));
+                    return String.format("%.2f MB", (bytes / ONE_MB));
                 }
-                return bytes + "bytes";
+                return bytes + " bytes";
             }
         };
 
@@ -199,6 +224,10 @@ public final class DockerRestClient
             .withTag(tag)
             .exec(callback)
             .awaitCompletion();
+
+        final long elapsedMs = (System.nanoTime() - startTime) / 1_000_000;
+        LOGGER.info("Pull complete for {}:{} in {}.{}s",
+            repository, tag, elapsedMs / 1000, String.format("%03d", elapsedMs % 1000));
     }
 
     public void tagImage(

--- a/docker-versions-maven-plugin/src/main/java/com/github/cafapi/docker_versions/docker/client/DockerRestClient.java
+++ b/docker-versions-maven-plugin/src/main/java/com/github/cafapi/docker_versions/docker/client/DockerRestClient.java
@@ -126,7 +126,7 @@ public final class DockerRestClient
 
             /**
              * This method logs pull progress when images are pulled from docker.
-             * @param item
+             * @param item the pull response item containing the status and progress information
              */
             @Override
             public void onNext(final PullResponseItem item) {


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=1200007

Changes:
1. Fixes critical bug — logging code can abort an otherwise-successful pull. In `onNext` (line 170), `stringifyBytes(totalBytes.get(itemId))` unboxes a `Long`. `totalBytes` only contains an entry for a layer once *that layer* reports `total > 0`. If the blended/aggregate percentage crosses a new 10% threshold on an event for a layer whose own total is still unknown (real registries omit `total` on early chunked-transfer progress events — `ResponseItem.getTotal()` is explicitly `@CheckForNull`), `totalBytes.get(itemId)` is `null` → `NullPointerException`.
2. Logs `Download complete`, `Already exists`, and `Pull complete`.
3. Renamed variables to better indicate "pull" actions and response details.